### PR TITLE
Single price route with disambiguation for ambiguous symbols

### DIFF
--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,33 +1,77 @@
 class SlackController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  def stocks
-    stock_input = params[:text].strip.downcase
-    quote = get_stock_quote(stock_input)
+  CRYPTO_SYMBOLS = %w[BTC ETH].freeze
+
+  AMBIGUOUS_SYMBOLS = {
+    "XRP"  => { crypto_name: "Ripple",       stock_name: "Bitwise XRP ETF" },
+    "BCH"  => { crypto_name: "Bitcoin Cash", stock_name: "Banco de Chile" },
+    "LINK" => { crypto_name: "Chainlink",    stock_name: "Interlink Electronics" }
+  }.freeze
+
+  def price
+    input = params[:text].strip.upcase
+
+    if AMBIGUOUS_SYMBOLS.key?(input)
+      meta = AMBIGUOUS_SYMBOLS[input]
+      render json: {
+        response_type: "ephemeral",
+        blocks: [
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: "Which *#{input}* did you mean?" }
+          },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "#{input} — #{meta[:crypto_name]} (Crypto)" },
+                value: "#{input}|crypto",
+                action_id: "price_crypto"
+              },
+              {
+                type: "button",
+                text: { type: "plain_text", text: "#{input} — #{meta[:stock_name]} (Stock)" },
+                value: "#{input}|stock",
+                action_id: "price_stock"
+              }
+            ]
+          }
+        ]
+      }
+      return
+    end
+
+    symbol = CRYPTO_SYMBOLS.include?(input) ? "#{input}/USD" : input
+    quote = get_quote(symbol)
+
+    if quote.nil? && !CRYPTO_SYMBOLS.include?(input)
+      quote = get_quote("#{input}/USD")
+      symbol = "#{input}/USD"
+    end
+
     render json: {
-         response_type: "in_channel",
-         text: format_message(stock_input.upcase, quote)
-       }
+      response_type: "in_channel",
+      text: format_message(symbol, quote)
+    }
   end
 
-  def crypto
-    crypto_input = params[:text].strip.downcase
-    quote = get_crypto_quote(crypto_input)
+  def interactions
+    payload = JSON.parse(params[:payload])
+    action = payload["actions"].first
+    symbol, type = action["value"].split("|")
+
+    twelve_data_symbol = type == "crypto" ? "#{symbol}/USD" : symbol
+    quote = get_quote(twelve_data_symbol)
+
     render json: {
-        response_type: "in_channel",
-        text: format_message(crypto_input.upcase, quote)
-      }
+      response_type: "in_channel",
+      text: format_message(twelve_data_symbol, quote)
+    }
   end
 
   private
-
-  def get_crypto_quote(crypto_symbol)
-    get_quote("#{crypto_symbol}/USD")
-  end
-
-  def get_stock_quote(stock_symbol)
-    get_quote(stock_symbol)
-  end
 
   def get_quote(symbol)
     url = ENV['TWELVE_DATA_URL'] + symbol + "&apikey=" + ENV['TWELVE_DATA_API_KEY']

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -70,6 +70,7 @@ class SlackController < ApplicationController
       headers: { "Content-Type" => "application/json" },
       body: {
         response_type: "in_channel",
+        replace_original: false,
         text: format_message(twelve_data_symbol, quote)
       }.to_json
     })

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -60,15 +60,21 @@ class SlackController < ApplicationController
   def interactions
     payload = JSON.parse(params[:payload])
     action = payload["actions"].first
+    response_url = payload["response_url"]
     symbol, type = action["value"].split("|")
 
     twelve_data_symbol = type == "crypto" ? "#{symbol}/USD" : symbol
     quote = get_quote(twelve_data_symbol)
 
-    render json: {
-      response_type: "in_channel",
-      text: format_message(twelve_data_symbol, quote)
-    }
+    HTTParty.post(response_url, {
+      headers: { "Content-Type" => "application/json" },
+      body: {
+        response_type: "in_channel",
+        text: format_message(twelve_data_symbol, quote)
+      }.to_json
+    })
+
+    render json: {}, status: :ok
   end
 
   private

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -66,13 +66,15 @@ class SlackController < ApplicationController
     twelve_data_symbol = type == "crypto" ? "#{symbol}/USD" : symbol
     quote = get_quote(twelve_data_symbol)
 
-    HTTParty.post(response_url, {
+    delete_response = HTTParty.post(response_url, {
       headers: { "Content-Type" => "application/json" },
       body: { delete_original: true }.to_json
     })
+    Rails.logger.info("Delete response: #{delete_response.body}")
 
     channel = payload["channel"]["id"]
-    HTTParty.post("https://slack.com/api/chat.postMessage", {
+    Rails.logger.info("Posting to channel: #{channel}")
+    post_response = HTTParty.post("https://slack.com/api/chat.postMessage", {
       headers: {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{ENV['SLACK_BOT_TOKEN']}"
@@ -82,6 +84,7 @@ class SlackController < ApplicationController
         text: format_message(twelve_data_symbol, quote)
       }.to_json
     })
+    Rails.logger.info("Post response: #{post_response.body}")
 
     render json: {}, status: :ok
   end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -68,15 +68,17 @@ class SlackController < ApplicationController
 
     HTTParty.post(response_url, {
       headers: { "Content-Type" => "application/json" },
-      body: {
-        delete_original: true
-      }.to_json
+      body: { delete_original: true }.to_json
     })
 
-    HTTParty.post(response_url, {
-      headers: { "Content-Type" => "application/json" },
+    channel = payload["channel"]["id"]
+    HTTParty.post("https://slack.com/api/chat.postMessage", {
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{ENV['SLACK_BOT_TOKEN']}"
+      },
       body: {
-        response_type: "in_channel",
+        channel: channel,
         text: format_message(twelve_data_symbol, quote)
       }.to_json
     })

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -69,8 +69,14 @@ class SlackController < ApplicationController
     HTTParty.post(response_url, {
       headers: { "Content-Type" => "application/json" },
       body: {
+        delete_original: true
+      }.to_json
+    })
+
+    HTTParty.post(response_url, {
+      headers: { "Content-Type" => "application/json" },
+      body: {
         response_type: "in_channel",
-        replace_original: false,
         text: format_message(twelve_data_symbol, quote)
       }.to_json
     })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   post '/slack/commands', to: 'slack#commands'
-  post 'slack/stocks', to: 'slack#stocks'
-  post 'slack/crypto', to: 'slack#crypto'
+  post 'slack/price', to: 'slack#price'
+  post 'slack/interactions', to: 'slack#interactions'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## Summary
- Consolidated `/slack/crypto` and `/slack/stocks` into a single `/slack/price` route
- BTC and ETH are hardcoded as crypto (they have Grayscale ETF stock conflicts but users always mean the crypto)
- XRP, BCH, and LINK show interactive disambiguation buttons since they have genuine stock conflicts
- Button click posts result to channel via `chat.postMessage` and removes the ephemeral button message
- Added `/slack/interactions` endpoint to handle button clicks

## Test plan
- [ ] `/price ETH` — returns crypto price directly
- [ ] `/price AAPL` — returns stock price directly
- [ ] `/price XRP` — shows disambiguation buttons, clicking posts to channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)