### PR TITLE
Add README and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TWELVE_DATA_API_KEY = ""
+TWELVE_DATA_URL = "https://api.twelvedata.com/quote?symbol="
+SLACK_BOT_TOKEN = ""

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/README.md
+++ b/README.md
@@ -1,24 +1,55 @@
-# README
+# Crypto Price Bot
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+A Rails Slack bot that returns real-time stock and crypto prices via slash commands, powered by the [Twelve Data API](https://twelvedata.com).
 
-Things you may want to cover:
+## Features
 
-* Ruby version
+- Look up stock and crypto prices with a single `/price` command
+- 24hr price change with up/down indicator
+- Automatically disambiguates symbols that match both a stock and a crypto (e.g. XRP, BCH, LINK) via interactive buttons
 
-* System dependencies
+## Requirements
 
-* Configuration
+- Ruby 3.0.2
+- Rails 7.1
+- A [Twelve Data](https://twelvedata.com) account (free tier supported)
+- A Slack app with slash commands and interactive components enabled
 
-* Database creation
+## Environment Variables
 
-* Database initialization
+Copy `.env.example` to `.env` and fill in the values:
 
-* How to run the test suite
+| Variable | Description |
+|----------|-------------|
+| `TWELVE_DATA_API_KEY` | Your Twelve Data API key |
+| `TWELVE_DATA_URL` | Twelve Data quote endpoint — `https://api.twelvedata.com/quote?symbol=` |
+| `SLACK_BOT_TOKEN` | Your Slack bot token (`xoxb-...`) |
 
-* Services (job queues, cache servers, search engines, etc.)
+## Slack App Setup
 
-* Deployment instructions
+1. Create a new app at [api.slack.com/apps](https://api.slack.com/apps)
+2. Under **OAuth & Permissions**, add the following bot token scopes:
+   - `commands`
+   - `chat:write`
+   - `chat:write.public` (to post in public channels without joining)
+3. Under **Slash Commands**, create a `/price` command pointing to `https://your-domain.com/slack/price`
+4. Under **Interactivity & Shortcuts**, enable interactivity and set the request URL to `https://your-domain.com/slack/interactions`
+5. Install the app to your workspace and copy the bot token to your `.env`
 
-* ...
+## Running Locally
+
+```bash
+bundle install
+cp .env.example .env  # fill in your keys
+./bin/rails server
+```
+
+## Usage
+
+In any Slack channel the bot has been invited to:
+
+```
+/price ETH      # Ethereum price
+/price AAPL     # Apple stock price
+/price XRP      # Shows disambiguation buttons (crypto vs stock)
+```


### PR DESCRIPTION
## Summary
- Replaced the default Rails README with actual setup and usage instructions
- Added `.env.example` with all required environment variables
- Updated `.gitignore` to allow `.env.example` to be committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)